### PR TITLE
refactor(core): remove "any" from Google Picker callback data

### DIFF
--- a/packages/google-drive-picker/core/src/picker/createPicker.ts
+++ b/packages/google-drive-picker/core/src/picker/createPicker.ts
@@ -1,4 +1,8 @@
-import type { GoogleDriveFile, GoogleDrivePickerConfig } from "../types";
+import type {
+	GoogleDriveFile,
+	GoogleDrivePickerConfig,
+	PickerCallbackData,
+} from "../types";
 
 /**
  * Options required to create and display the Google Drive Picker.
@@ -33,10 +37,10 @@ const createPicker = (options: CreatePickerOptions) => {
 		)
 		.setOAuthToken(oauthToken)
 		.setDeveloperKey(apiKey)
-		.setCallback((data: any) => {
+		.setCallback((data: PickerCallbackData) => {
 			if (data.action === window.google?.picker?.Action?.PICKED) {
 				const files = data.docs.map(
-					(doc: any): GoogleDriveFile => ({
+					(doc): GoogleDriveFile => ({
 						id: doc.id,
 						serviceId: doc.serviceId,
 						mimeType: doc.mimeType,

--- a/packages/google-drive-picker/core/src/types/picker.ts
+++ b/packages/google-drive-picker/core/src/types/picker.ts
@@ -52,3 +52,25 @@ export type GoogleDriveScope =
 	| "https://www.googleapis.com/auth/drive.photos.readonly" // Read-only access to photos, videos, and albums in Google Photos
 	| "https://www.googleapis.com/auth/drive.readonly" // Read-only access to all Google Drive files
 	| "https://www.googleapis.com/auth/drive.scripts"; // Manage Google Apps Script
+
+// Interface representing the PickerBuilder instance
+export interface PickerBuilder {
+	addView: (viewId: string) => PickerBuilder;
+	setOAuthToken: (token: string) => PickerBuilder;
+	setDeveloperKey: (apiKey: string) => PickerBuilder;
+	setCallback: (
+		callback: (data: PickerCallbackData) => void,
+	) => PickerBuilder;
+	enableFeature: (feature: string) => PickerBuilder;
+	build: () => {
+		setVisible: (visible: boolean) => void;
+	};
+}
+
+export type PickerCallbackData = {
+	action?: string; // This remains string-typed until further refinement
+	docs: Array<GoogleDriveFile>;
+};
+
+// Type for the PickerBuilder constructor
+export type PickerBuilderConstructor = new () => PickerBuilder;

--- a/packages/google-drive-picker/core/src/types/window.ts
+++ b/packages/google-drive-picker/core/src/types/window.ts
@@ -1,4 +1,5 @@
 import type { GoogleTokenClient, GoogleTokenClientConfig } from "./identity";
+import type { PickerBuilderConstructor } from "./picker";
 
 declare global {
 	interface Window {
@@ -11,7 +12,7 @@ declare global {
 				};
 			};
 			picker?: {
-				PickerBuilder: any;
+				PickerBuilder: PickerBuilderConstructor;
 				Action: {
 					PICKED: string;
 					CANCEL: string;


### PR DESCRIPTION
- Replaced `any` type in `setCallback` for picker data and docs with defined `PickerCallbackData` type
- Enhanced type safety for Google Picker callback, specifying structure for `action` and `docs` properties
- Updated `window.ts` to better define PickerBuilder and callback data